### PR TITLE
RNMT-5302 Podfile generation when app name has apostrophes

### DIFF
--- a/bin/templates/scripts/cordova/lib/Podfile.js
+++ b/bin/templates/scripts/cordova/lib/Podfile.js
@@ -78,7 +78,7 @@ Podfile.prototype.__parseForDeclarations = function (text) {
 
     // getting lines between "platform :ios, '11.0'"" and "target 'HelloCordova'" do
     const declarationsPreRE = new RegExp('platform :ios,\\s+\'[^\']+\'');
-    const declarationsPostRE = new RegExp('target\\s+\'[^\']+\'\\s+do');
+    const declarationsPostRE = new RegExp('target\\s+\'.+\'\\s+do');
     const declarationRE = new RegExp('^\\s*[^#]');
 
     return arr.reduce((acc, line) => {


### PR DESCRIPTION
Changes a regex that detects where to write the Pod entries in the Podfile that was not handling targets with 's correctly.

Fixes https://outsystemsrd.atlassian.net/browse/RNMT-5302