### PR TITLE
RNMT-5719 Disable Mac target

### DIFF
--- a/bin/templates/scripts/cordova/lib/prepare.js
+++ b/bin/templates/scripts/cordova/lib/prepare.js
@@ -271,6 +271,9 @@ function handleBuildSettings (platformConfig, locations, infoPlist) {
     const deploymentTarget = platformConfig.getPreference('deployment-target', 'ios');
     const swiftVersion = platformConfig.getPreference('SwiftVersion', 'ios');
 
+    const supportMac = platformConfig.getPreference('SupportMac', 'ios');
+    const disableMacTarget = !supportMac || supportMac.toString().toLowerCase() !== 'true';
+
     let project;
 
     try {
@@ -283,7 +286,7 @@ function handleBuildSettings (platformConfig, locations, infoPlist) {
 
     // no build settings provided and we don't need to update build settings for launch storyboards,
     // then we don't need to parse and update .pbxproj file
-    if (origPkg === pkg && !targetDevice && !deploymentTarget && !swiftVersion) {
+    if (origPkg === pkg && !targetDevice && !deploymentTarget && !swiftVersion && !disableMacTarget) {
         return Promise.resolve();
     }
 
@@ -305,6 +308,19 @@ function handleBuildSettings (platformConfig, locations, infoPlist) {
     if (swiftVersion) {
         events.emit('verbose', `Set SwiftVersion to "${swiftVersion}".`);
         project.xcode.updateBuildProperty('SWIFT_VERSION', swiftVersion);
+    }
+
+    if (disableMacTarget) {
+        events.emit('verbose', 'Disable MacOS target.');
+        // This whole conundrum is required in order to only change the settings of the PBXNativeTarget and not the PBXProject
+        Object.values(project.xcode.pbxNativeTargetSection())
+            .filter((item) => item.isa === 'PBXNativeTarget' && item.name)
+            .forEach((item) => {
+                const target = item.name.replace(/^['"]*|['"]*$/g, ''); // Remove leading and trailing quotes
+                project.xcode.updateBuildProperty('SUPPORTED_PLATFORMS', '"iphoneos iphonesimulator"', undefined, target);
+                project.xcode.updateBuildProperty('SUPPORTS_MACCATALYST', 'NO', undefined, target);
+                project.xcode.updateBuildProperty('SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD', 'NO', undefined, target);
+            });
     }
 
     project.write();


### PR DESCRIPTION
### Description
<!-- Describe your changes in detail -->
This PR disables the Mac target and allows to change this behaviour using a preference called `SupportMac`.

Credits to @usernuno, my job here was only to test and open the PR.

### Platforms affected
iOS

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Closes https://outsystemsrd.atlassian.net/browse/RNMT-5719


### Testing
<!-- Please describe in detail how you tested your changes. -->
Created a local iOS Cordova project based on this cordova-ios branch and the .pbxproj was:
- updated when the preference `SupportMac` is not set
- updated when the preference `SupportMac` is set with the value `false`
- NOT updated when the preference `SupportMac` is set with the value `true`

### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
