### PR TITLE
RNMT-5719 Add preference to disable MacOS target

### DIFF
--- a/bin/templates/scripts/cordova/lib/prepare.js
+++ b/bin/templates/scripts/cordova/lib/prepare.js
@@ -271,6 +271,9 @@ function handleBuildSettings (platformConfig, locations, infoPlist) {
     const deploymentTarget = platformConfig.getPreference('deployment-target', 'ios');
     const swiftVersion = platformConfig.getPreference('SwiftVersion', 'ios');
 
+    const supportMac = platformConfig.getPreference('SupportMac', 'ios');
+    const disableMacTarget = supportMac !== undefined && supportMac.toString().toLowerCase() === 'false';
+
     let project;
 
     try {
@@ -283,7 +286,7 @@ function handleBuildSettings (platformConfig, locations, infoPlist) {
 
     // no build settings provided and we don't need to update build settings for launch storyboards,
     // then we don't need to parse and update .pbxproj file
-    if (origPkg === pkg && !targetDevice && !deploymentTarget && !swiftVersion) {
+    if (origPkg === pkg && !targetDevice && !deploymentTarget && !swiftVersion && !disableMacTarget) {
         return Promise.resolve();
     }
 
@@ -305,6 +308,19 @@ function handleBuildSettings (platformConfig, locations, infoPlist) {
     if (swiftVersion) {
         events.emit('verbose', `Set SwiftVersion to "${swiftVersion}".`);
         project.xcode.updateBuildProperty('SWIFT_VERSION', swiftVersion);
+    }
+
+    if (disableMacTarget) {
+        events.emit('verbose', 'Disable MacOS target.');
+        // This whole conundrum is required in order to only change the settings of the PBXNativeTarget and not the PBXProject
+        Object.values(project.xcode.pbxNativeTargetSection())
+            .filter((item) => item.isa === 'PBXNativeTarget' && item.name)
+            .forEach((item) => {
+                const target = item.name.replace(/^['"]*|['"]*$/g, ''); // Remove leading and trailing quotes
+                project.xcode.updateBuildProperty('SUPPORTED_PLATFORMS', '"iphoneos iphonesimulator"', undefined, target);
+                project.xcode.updateBuildProperty('SUPPORTS_MACCATALYST', 'NO', undefined, target);
+                project.xcode.updateBuildProperty('SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD', 'NO', undefined, target);
+            });
     }
 
     project.write();

--- a/tests/spec/unit/fixtures/test-config-3.xml
+++ b/tests/spec/unit/fixtures/test-config-3.xml
@@ -14,6 +14,7 @@
         <preference name="target-device" value="handset" />
         <preference name="deployment-target" value="11.0" />
         <preference name="SwiftVersion" value="4.1" />
+        <preference name="SupportMac" value="true" />
     </platform>
 
     <access origin="http://*.apache.org" />

--- a/tests/spec/unit/prepare.spec.js
+++ b/tests/spec/unit/prepare.spec.js
@@ -654,6 +654,60 @@ describe('prepare', () => {
             });
         });
 
+        it('should support Mac apps by default', () => {
+            cfg2.name = () => 'SampleApp'; // new config does *not* have a name change
+            writeFileSyncSpy.and.callThrough();
+            return updateProject(cfg2, p.locations).then(() => {
+                const xcode = require('xcode');
+                const proj = new xcode.project(p.locations.pbxproj); /* eslint new-cap : 0 */
+                proj.parseSync();
+                const supportedPlatforms = proj.getBuildProperty('SUPPORTED_PLATFORMS');
+                expect(supportedPlatforms).toBeUndefined();
+                const supportsMacCatalyst = proj.getBuildProperty('SUPPORTS_MACCATALYST');
+                expect(supportsMacCatalyst).toBeUndefined();
+                const supportsMacIPhoneIPad = proj.getBuildProperty('SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD');
+                expect(supportsMacIPhoneIPad).toBeUndefined();
+            });
+        });
+
+        it('should support Mac apps if SupportMac preference is set to true', () => {
+            cfg3.name = () => 'SampleApp'; // new config does *not* have a name change
+            const pref = cfg3.doc.findall('platform[@name=\'ios\']/preference')
+                .filter(elem => elem.attrib.name.toLowerCase() === 'supportmac')[0];
+            pref.attrib.value = 'true';
+            writeFileSyncSpy.and.callThrough();
+            return updateProject(cfg3, p.locations).then(() => {
+                const xcode = require('xcode');
+                const proj = new xcode.project(p.locations.pbxproj); /* eslint new-cap : 0 */
+                proj.parseSync();
+                const supportedPlatforms = proj.getBuildProperty('SUPPORTED_PLATFORMS');
+                expect(supportedPlatforms).toBeUndefined();
+                const supportsMacCatalyst = proj.getBuildProperty('SUPPORTS_MACCATALYST');
+                expect(supportsMacCatalyst).toBeUndefined();
+                const supportsMacIPhoneIPad = proj.getBuildProperty('SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD');
+                expect(supportsMacIPhoneIPad).toBeUndefined();
+            });
+        });
+
+        it('should not support Mac apps if SupportMac preference is set to false', () => {
+            cfg3.name = () => 'SampleApp'; // new config does *not* have a name change
+            const pref = cfg3.doc.findall('platform[@name=\'ios\']/preference')
+                .filter(elem => elem.attrib.name.toLowerCase() === 'supportmac')[0];
+            pref.attrib.value = 'false';
+            writeFileSyncSpy.and.callThrough();
+            return updateProject(cfg3, p.locations).then(() => {
+                const xcode = require('xcode');
+                const proj = new xcode.project(p.locations.pbxproj); /* eslint new-cap : 0 */
+                proj.parseSync();
+                const supportedPlatforms = proj.getBuildProperty('SUPPORTED_PLATFORMS');
+                expect(supportedPlatforms).toEqual('"iphoneos iphonesimulator"');
+                const supportsMacCatalyst = proj.getBuildProperty('SUPPORTS_MACCATALYST');
+                expect(supportsMacCatalyst).toEqual('NO');
+                const supportsMacIPhoneIPad = proj.getBuildProperty('SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD');
+                expect(supportsMacIPhoneIPad).toEqual('NO');
+            });
+        });
+
         it('Test#002 : should write out the app id to info plist as CFBundleIdentifier', () => {
             const orig = cfg.getAttribute;
             cfg.getAttribute = function (name) {


### PR DESCRIPTION
### Description
<!-- Describe your changes in detail -->
This PR adds a preference called `SupportMac` to enable/disable the MacOS target.
By default, it is enabled.

Credits to @usernuno.

### Platforms affected
iOS

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Closes https://outsystemsrd.atlassian.net/browse/RNMT-5719


### Testing
<!-- Please describe in detail how you tested your changes. -->
Created a local iOS Cordova project based on this cordova-ios branch and the .pbxproj was:
- NOT updated when the preference `SupportMac` is not set
- NOT updated when the preference `SupportMac` is set with the value `true`
- updated when the preference `SupportMac` is set with the value `false`

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
