### PR TITLE
RNMT-6172 Prepare our fork of cordova-ios 7.0.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,17 +48,13 @@ jobs:
         env:
           CI: true
 
-      - uses: codecov/codecov-action@v3
-        with:
-          fail_ci_if_error: true
-
   non-darwin:
     name: NodeJS ${{ matrix.node-version }} on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         node-version: [16.x, 18.x, 20.x]
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest]
 
     steps:
       - uses: actions/checkout@v3
@@ -80,7 +76,3 @@ jobs:
           npm run unit-tests
         env:
           CI: true
-
-      - uses: codecov/codecov-action@v3
-        with:
-          fail_ci_if_error: true

--- a/CordovaLib/include/Cordova/CDVAvailability.h
+++ b/CordovaLib/include/Cordova/CDVAvailability.h
@@ -78,6 +78,8 @@
 #define __CORDOVA_6_0_0 60000
 #define __CORDOVA_6_1_0 60100
 #define __CORDOVA_6_2_0 60200
+#define __CORDOVA_6_3_0 60300
+#define __CORDOVA_7_0_0 70000
 /* coho:next-version,insert-before */
 #define __CORDOVA_NA 99999      /* not available */
 
@@ -90,7 +92,7 @@
  */
 #ifndef CORDOVA_VERSION_MIN_REQUIRED
     /* coho:next-version-min-required,replace-after */
-    #define CORDOVA_VERSION_MIN_REQUIRED __CORDOVA_6_2_0
+    #define CORDOVA_VERSION_MIN_REQUIRED __CORDOVA_7_0_0
 #endif
 
 /*

--- a/lib/Podfile.js
+++ b/lib/Podfile.js
@@ -75,7 +75,7 @@ Podfile.prototype.__parseForDeclarations = function (text) {
 
     // getting lines between "platform :ios, '11.0'"" and "target 'HelloCordova'" do
     const declarationsPreRE = /platform :ios,\s+'[^']+'/;
-    const declarationsPostRE = /target\s+'[^']+'\s+do/;
+    const declarationsPostRE = /target\s+'.+'\s+do/;
     const declarationRE = /^\s*[^#]/;
 
     return arr.reduce((acc, line) => {

--- a/lib/prepare.js
+++ b/lib/prepare.js
@@ -273,6 +273,9 @@ function handleBuildSettings (platformConfig, locations, infoPlist) {
     const deploymentTarget = platformConfig.getPreference('deployment-target', 'ios');
     const swiftVersion = platformConfig.getPreference('SwiftVersion', 'ios');
 
+    const supportMac = platformConfig.getPreference('SupportMac', 'ios');
+    const disableMacTarget = supportMac !== undefined && supportMac.toString().toLowerCase() === 'false';
+
     let project;
 
     try {
@@ -285,7 +288,7 @@ function handleBuildSettings (platformConfig, locations, infoPlist) {
 
     // no build settings provided and we don't need to update build settings for launch storyboards,
     // then we don't need to parse and update .pbxproj file
-    if (origPkg === pkg && !targetDevice && !deploymentTarget && !swiftVersion) {
+    if (origPkg === pkg && !targetDevice && !deploymentTarget && !swiftVersion && !disableMacTarget) {
         return Promise.resolve();
     }
 
@@ -307,6 +310,19 @@ function handleBuildSettings (platformConfig, locations, infoPlist) {
     if (swiftVersion) {
         events.emit('verbose', `Set SwiftVersion to "${swiftVersion}".`);
         project.xcode.updateBuildProperty('SWIFT_VERSION', swiftVersion);
+    }
+
+    if (disableMacTarget) {
+        events.emit('verbose', 'Disable MacOS target.');
+        // This whole conundrum is required in order to only change the settings of the PBXNativeTarget and not the PBXProject
+        Object.values(project.xcode.pbxNativeTargetSection())
+            .filter((item) => item.isa === 'PBXNativeTarget' && item.name)
+            .forEach((item) => {
+                const target = item.name.replace(/^['"]*|['"]*$/g, ''); // Remove leading and trailing quotes
+                project.xcode.updateBuildProperty('SUPPORTED_PLATFORMS', '"iphoneos iphonesimulator"', undefined, target);
+                project.xcode.updateBuildProperty('SUPPORTS_MACCATALYST', 'NO', undefined, target);
+                project.xcode.updateBuildProperty('SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD', 'NO', undefined, target);
+            });
     }
 
     project.write();

--- a/templates/project/__PROJECT_NAME__.xcodeproj/project.pbxproj
+++ b/templates/project/__PROJECT_NAME__.xcodeproj/project.pbxproj
@@ -58,7 +58,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
-		0207DA571B56EA530066E2B4 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Assets.xcassets; sourceTree = "<group>"; };
+		0207DA571B56EA530066E2B4 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		1D3623240D0F684500981E51 /* AppDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AppDelegate.h; sourceTree = "<group>"; };
 		1D3623250D0F684500981E51 /* AppDelegate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AppDelegate.m; sourceTree = "<group>"; };
 		1D6058910D05DD3D006BFB54 /* __PROJECT_NAME__.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "__PROJECT_NAME__.app"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -72,8 +72,8 @@
 		3047A5101AB8059700498E2A /* build-release.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = "build-release.xcconfig"; path = "cordova/build-release.xcconfig"; sourceTree = SOURCE_ROOT; };
 		3047A5111AB8059700498E2A /* build.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = build.xcconfig; path = cordova/build.xcconfig; sourceTree = SOURCE_ROOT; };
 		32CA4F630368D1EE00C91783 /* __PROJECT_NAME__-Prefix.pch */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "__PROJECT_NAME__-Prefix.pch"; sourceTree = "<group>"; };
-		6AFF5BF81D6E424B00AB3073 /* CDVLaunchScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = CDVLaunchScreen.storyboard; sourceTree = "<group>"; };
-		8D1107310486CEB800E47090 /* __PROJECT_NAME__-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = "__PROJECT_NAME__-Info.plist"; plistStructureDefinitionIdentifier = "com.apple.xcode.plist.structure-definition.iphone.info-plist"; sourceTree = "<group>"; };
+		6AFF5BF81D6E424B00AB3073 /* CDVLaunchScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = CDVLaunchScreen.storyboard; sourceTree = "<group>"; };
+		8D1107310486CEB800E47090 /* __PROJECT_NAME__-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "__PROJECT_NAME__-Info.plist"; plistStructureDefinitionIdentifier = "com.apple.xcode.plist.structure-definition.iphone.info-plist"; sourceTree = "<group>"; };
 		EB87FDF31871DA8E0020F90C /* www */ = {isa = PBXFileReference; lastKnownFileType = folder; name = www; path = ../../www; sourceTree = "<group>"; };
 		EB87FDF41871DAF40020F90C /* config.xml */ = {isa = PBXFileReference; lastKnownFileType = text.xml; name = config.xml; path = ../../config.xml; sourceTree = "<group>"; };
 		ED33DF2A687741AEAF9F8254 /* Bridging-Header.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "Bridging-Header.h"; sourceTree = "<group>"; };

--- a/tests/spec/unit/fixtures/test-config-3.xml
+++ b/tests/spec/unit/fixtures/test-config-3.xml
@@ -14,6 +14,7 @@
         <preference name="target-device" value="handset" />
         <preference name="deployment-target" value="11.0" />
         <preference name="SwiftVersion" value="4.1" />
+        <preference name="SupportMac" value="true" />
     </platform>
 
     <access origin="http://*.apache.org" />

--- a/tests/spec/unit/prepare.spec.js
+++ b/tests/spec/unit/prepare.spec.js
@@ -649,6 +649,57 @@ describe('prepare', () => {
             });
         });
 
+        it('should support Mac apps by default', () => {
+            cfg2.name = () => 'SampleApp'; // new config does *not* have a name change
+            writeFileSyncSpy.and.callThrough();
+            return updateProject(cfg2, p.locations).then(() => {
+                const proj = new XcodeProject(p.locations.pbxproj); /* eslint new-cap : 0 */
+                proj.parseSync();
+                const supportedPlatforms = proj.getBuildProperty('SUPPORTED_PLATFORMS');
+                expect(supportedPlatforms).toBeUndefined();
+                const supportsMacCatalyst = proj.getBuildProperty('SUPPORTS_MACCATALYST');
+                expect(supportsMacCatalyst).toEqual('YES');
+                const supportsMacIPhoneIPad = proj.getBuildProperty('SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD');
+                expect(supportsMacIPhoneIPad).toBeUndefined();
+            });
+        });
+
+        it('should support Mac apps if SupportMac preference is set to true', () => {
+            cfg3.name = () => 'SampleApp'; // new config does *not* have a name change
+            const pref = cfg3.doc.findall('platform[@name=\'ios\']/preference')
+                .filter(elem => elem.attrib.name.toLowerCase() === 'supportmac')[0];
+            pref.attrib.value = 'true';
+            writeFileSyncSpy.and.callThrough();
+            return updateProject(cfg3, p.locations).then(() => {
+                const proj = new XcodeProject(p.locations.pbxproj); /* eslint new-cap : 0 */
+                proj.parseSync();
+                const supportedPlatforms = proj.getBuildProperty('SUPPORTED_PLATFORMS');
+                expect(supportedPlatforms).toBeUndefined();
+                const supportsMacCatalyst = proj.getBuildProperty('SUPPORTS_MACCATALYST');
+                expect(supportsMacCatalyst).toEqual('YES');
+                const supportsMacIPhoneIPad = proj.getBuildProperty('SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD');
+                expect(supportsMacIPhoneIPad).toBeUndefined();
+            });
+        });
+
+        it('should not support Mac apps if SupportMac preference is set to false', () => {
+            cfg3.name = () => 'SampleApp'; // new config does *not* have a name change
+            const pref = cfg3.doc.findall('platform[@name=\'ios\']/preference')
+                .filter(elem => elem.attrib.name.toLowerCase() === 'supportmac')[0];
+            pref.attrib.value = 'false';
+            writeFileSyncSpy.and.callThrough();
+            return updateProject(cfg3, p.locations).then(() => {
+                const proj = new XcodeProject(p.locations.pbxproj); /* eslint new-cap : 0 */
+                proj.parseSync();
+                const supportedPlatforms = proj.getBuildProperty('SUPPORTED_PLATFORMS');
+                expect(supportedPlatforms).toEqual('"iphoneos iphonesimulator"');
+                const supportsMacCatalyst = proj.getBuildProperty('SUPPORTS_MACCATALYST');
+                expect(supportsMacCatalyst).toEqual('NO');
+                const supportsMacIPhoneIPad = proj.getBuildProperty('SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD');
+                expect(supportsMacIPhoneIPad).toEqual('NO');
+            });
+        });
+
         it('Test#002 : should write out the app id to info plist as CFBundleIdentifier', () => {
             const orig = cfg.getAttribute;
             cfg.getAttribute = function (name) {


### PR DESCRIPTION
This adds 4 commits above the 7.0.0 version from upstream:

- Fix podfile generation when app name has apostrophes (from our 6.2.0 fork)
- Add preference to disable MacOS target (from our 6.2.0 fork)
- Ensure Xcode project file references use path (a required fix from https://github.com/apache/cordova-ios/pull/1358)
- Add missing cordova versions to CDVAvailability.h (fix from https://github.com/apache/cordova-ios/pull/1360)

The remaining changes from our 6.2.0 fork are already handled in 7.0.0.