### PR TITLE
RNMT-6337 ::: MABS 10 ::: Fixes orientation changes from cordova-ios

### DIFF
--- a/CordovaLib/Classes/Public/CDVAppDelegate.m
+++ b/CordovaLib/Classes/Public/CDVAppDelegate.m
@@ -87,4 +87,11 @@
     return YES;
 }
 
+- (UIInterfaceOrientationMask)application:(UIApplication*)application supportedInterfaceOrientationsForWindow:(UIWindow*)window
+{
+    // iPhone doesn't support upside down by default, while the iPad does.  Override to allow all orientations always, and let the root view controller decide what's allowed (the supported orientations mask gets intersected).
+    NSUInteger supportedInterfaceOrientations = (1 << UIInterfaceOrientationPortrait) | (1 << UIInterfaceOrientationLandscapeLeft) | (1 << UIInterfaceOrientationLandscapeRight) | (1 << UIInterfaceOrientationPortraitUpsideDown);
+    return supportedInterfaceOrientations;
+}
+
 @end


### PR DESCRIPTION
This PR brings back a method that was removed in version 7.0.0 of cordova-ios
https://github.com/OutSystems/cordova-ios/commit/77b46896a43c6c3d5f9ce8ae85bfa84084993cce
Removing this causes crashes in the barcode plug-in and possibly in customer applications.
So, to avoid a breaking change we decided to keep it.

[More context here](https://outsystems.slack.com/archives/G0156FGB152/p1697791914237059)

Fixes https://outsystemsrd.atlassian.net/browse/RNMT-6337