### PR TITLE
RDMR-251 ::: Prepare our fork of cordova-ios 7.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,20 +48,13 @@ jobs:
         env:
           CI: true
 
-      - uses: codecov/codecov-action@v4
-        if: success()
-        with:
-          name: ${{ runner.os }} node.js ${{ matrix.node-version }} (darwin)
-          token: ${{ secrets.CORDOVA_CODECOV_TOKEN }}
-          fail_ci_if_error: false
-
   non-darwin:
     name: NodeJS ${{ matrix.node-version }} on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         node-version: [16.x, 18.x, 20.x]
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest]
 
     steps:
       - uses: actions/checkout@v4
@@ -83,10 +76,3 @@ jobs:
           npm run unit-tests
         env:
           CI: true
-
-      - uses: codecov/codecov-action@v4
-        if: success()
-        with:
-          name: ${{ runner.os }} node.js ${{ matrix.node-version }} (non-darwin)
-          token: ${{ secrets.CORDOVA_CODECOV_TOKEN }}
-          fail_ci_if_error: false

--- a/CordovaLib/Classes/Public/CDVAppDelegate.m
+++ b/CordovaLib/Classes/Public/CDVAppDelegate.m
@@ -87,4 +87,11 @@
     return YES;
 }
 
+- (UIInterfaceOrientationMask)application:(UIApplication*)application supportedInterfaceOrientationsForWindow:(UIWindow*)window
+{
+    // iPhone doesn't support upside down by default, while the iPad does.  Override to allow all orientations always, and let the root view controller decide what's allowed (the supported orientations mask gets intersected).
+    NSUInteger supportedInterfaceOrientations = (1 << UIInterfaceOrientationPortrait) | (1 << UIInterfaceOrientationLandscapeLeft) | (1 << UIInterfaceOrientationLandscapeRight) | (1 << UIInterfaceOrientationPortraitUpsideDown);
+    return supportedInterfaceOrientations;
+}
+
 @end

--- a/lib/Podfile.js
+++ b/lib/Podfile.js
@@ -75,7 +75,7 @@ Podfile.prototype.__parseForDeclarations = function (text) {
 
     // getting lines between "platform :ios, '11.0'"" and "target 'HelloCordova'" do
     const declarationsPreRE = /platform :ios,\s+'[^']+'/;
-    const declarationsPostRE = /target\s+'[^']+'\s+do/;
+    const declarationsPostRE = /target\s+'.+'\s+do/;
     const declarationRE = /^\s*[^#]/;
 
     return arr.reduce((acc, line) => {

--- a/lib/prepare.js
+++ b/lib/prepare.js
@@ -305,6 +305,9 @@ function handleBuildSettings (platformConfig, locations, infoPlist) {
     const deploymentTarget = platformConfig.getPreference('deployment-target', 'ios');
     const swiftVersion = platformConfig.getPreference('SwiftVersion', 'ios');
 
+    const supportMac = platformConfig.getPreference('SupportMac', 'ios');
+    const disableMacTarget = supportMac !== undefined && supportMac.toString().toLowerCase() === 'false';
+
     let project;
 
     try {
@@ -317,7 +320,7 @@ function handleBuildSettings (platformConfig, locations, infoPlist) {
 
     // no build settings provided and we don't need to update build settings for launch storyboards,
     // then we don't need to parse and update .pbxproj file
-    if (origPkg === pkg && !targetDevice && !deploymentTarget && !swiftVersion) {
+    if (origPkg === pkg && !targetDevice && !deploymentTarget && !swiftVersion && !disableMacTarget) {
         return Promise.resolve();
     }
 
@@ -339,6 +342,19 @@ function handleBuildSettings (platformConfig, locations, infoPlist) {
     if (swiftVersion) {
         events.emit('verbose', `Set SwiftVersion to "${swiftVersion}".`);
         project.xcode.updateBuildProperty('SWIFT_VERSION', swiftVersion);
+    }
+
+    if (disableMacTarget) {
+        events.emit('verbose', 'Disable MacOS target.');
+        // This whole conundrum is required in order to only change the settings of the PBXNativeTarget and not the PBXProject
+        Object.values(project.xcode.pbxNativeTargetSection())
+            .filter((item) => item.isa === 'PBXNativeTarget' && item.name)
+            .forEach((item) => {
+                const target = item.name.replace(/^['"]*|['"]*$/g, ''); // Remove leading and trailing quotes
+                project.xcode.updateBuildProperty('SUPPORTED_PLATFORMS', '"iphoneos iphonesimulator"', undefined, target);
+                project.xcode.updateBuildProperty('SUPPORTS_MACCATALYST', 'NO', undefined, target);
+                project.xcode.updateBuildProperty('SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD', 'NO', undefined, target);
+            });
     }
 
     project.write();

--- a/tests/spec/unit/fixtures/test-config-3.xml
+++ b/tests/spec/unit/fixtures/test-config-3.xml
@@ -14,6 +14,7 @@
         <preference name="target-device" value="handset" />
         <preference name="deployment-target" value="11.0" />
         <preference name="SwiftVersion" value="4.1" />
+        <preference name="SupportMac" value="true" />
     </platform>
 
     <access origin="http://*.apache.org" />

--- a/tests/spec/unit/prepare.spec.js
+++ b/tests/spec/unit/prepare.spec.js
@@ -649,6 +649,57 @@ describe('prepare', () => {
             });
         });
 
+        it('should support Mac apps by default', () => {
+            cfg2.name = () => 'SampleApp'; // new config does *not* have a name change
+            writeFileSyncSpy.and.callThrough();
+            return updateProject(cfg2, p.locations).then(() => {
+                const proj = new XcodeProject(p.locations.pbxproj); /* eslint new-cap : 0 */
+                proj.parseSync();
+                const supportedPlatforms = proj.getBuildProperty('SUPPORTED_PLATFORMS');
+                expect(supportedPlatforms).toBeUndefined();
+                const supportsMacCatalyst = proj.getBuildProperty('SUPPORTS_MACCATALYST');
+                expect(supportsMacCatalyst).toEqual('YES');
+                const supportsMacIPhoneIPad = proj.getBuildProperty('SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD');
+                expect(supportsMacIPhoneIPad).toBeUndefined();
+            });
+        });
+
+        it('should support Mac apps if SupportMac preference is set to true', () => {
+            cfg3.name = () => 'SampleApp'; // new config does *not* have a name change
+            const pref = cfg3.doc.findall('platform[@name=\'ios\']/preference')
+                .filter(elem => elem.attrib.name.toLowerCase() === 'supportmac')[0];
+            pref.attrib.value = 'true';
+            writeFileSyncSpy.and.callThrough();
+            return updateProject(cfg3, p.locations).then(() => {
+                const proj = new XcodeProject(p.locations.pbxproj); /* eslint new-cap : 0 */
+                proj.parseSync();
+                const supportedPlatforms = proj.getBuildProperty('SUPPORTED_PLATFORMS');
+                expect(supportedPlatforms).toBeUndefined();
+                const supportsMacCatalyst = proj.getBuildProperty('SUPPORTS_MACCATALYST');
+                expect(supportsMacCatalyst).toEqual('YES');
+                const supportsMacIPhoneIPad = proj.getBuildProperty('SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD');
+                expect(supportsMacIPhoneIPad).toBeUndefined();
+            });
+        });
+
+        it('should not support Mac apps if SupportMac preference is set to false', () => {
+            cfg3.name = () => 'SampleApp'; // new config does *not* have a name change
+            const pref = cfg3.doc.findall('platform[@name=\'ios\']/preference')
+                .filter(elem => elem.attrib.name.toLowerCase() === 'supportmac')[0];
+            pref.attrib.value = 'false';
+            writeFileSyncSpy.and.callThrough();
+            return updateProject(cfg3, p.locations).then(() => {
+                const proj = new XcodeProject(p.locations.pbxproj); /* eslint new-cap : 0 */
+                proj.parseSync();
+                const supportedPlatforms = proj.getBuildProperty('SUPPORTED_PLATFORMS');
+                expect(supportedPlatforms).toEqual('"iphoneos iphonesimulator"');
+                const supportsMacCatalyst = proj.getBuildProperty('SUPPORTS_MACCATALYST');
+                expect(supportsMacCatalyst).toEqual('NO');
+                const supportsMacIPhoneIPad = proj.getBuildProperty('SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD');
+                expect(supportsMacIPhoneIPad).toEqual('NO');
+            });
+        });
+
         it('Test#002 : should write out the app id to info plist as CFBundleIdentifier', () => {
             const orig = cfg.getAttribute;
             cfg.getAttribute = function (name) {


### PR DESCRIPTION
This adds 4 commits above the 7.1.1 version from upstream:

Fix podfile generation when app name has apostrophes (from our 6.2.0 fork)
Add preference to disable MacOS target (from our 6.2.0 fork)
Update CI for OutSystems requirements (from our 7.0.0 fork)
Revert orientation changes (from our 7.0.0 fork)
